### PR TITLE
[issue #66 ] CloseableResultSet (SELECT queries)

### DIFF
--- a/solrdf/solrdf-client/src/test/java/org/gazzax/labs/solrdf/client/SearchTestCase.java
+++ b/solrdf/solrdf-client/src/test/java/org/gazzax/labs/solrdf/client/SearchTestCase.java
@@ -2,15 +2,17 @@ package org.gazzax.labs.solrdf.client;
 
 import static org.mockito.Mockito.mock;
 
+import java.io.FileReader;
 import java.net.URI;
 
 import org.apache.solr.client.solrj.SolrServer;
+import org.gazzax.labs.solrdf.client.SolRDF.CloseableResultSet;
 import org.junit.Before;
 import org.junit.Ignore;
 
 import com.hp.hpl.jena.query.DatasetAccessor;
-import com.hp.hpl.jena.query.ResultSet;
 import com.hp.hpl.jena.query.ResultSetFormatter;
+import com.hp.hpl.jena.rdf.model.Model;
 
 /**
  * Test case which elencates several ways for adding data to SolRDF.
@@ -38,7 +40,7 @@ public class SearchTestCase {
 		uri = new URI("http://org.example.blablabla").toString();
 	}
 		
-	public static void main(String[] args) throws UnableToExecuteQueryException {
+	public static void main(String[] args) throws Exception {
 		try {
 			SolRDF solrdf = SolRDF.newBuilder()
 					.withEndpoint("http://127.0.0.1:8080/solr/store")
@@ -46,10 +48,22 @@ public class SearchTestCase {
 					.withSPARQLEndpointPath("/sparql")
 					.build();
 			
-			final ResultSet rs = solrdf.select("SELECT * FROM {?s ?p ?o}");
-			ResultSetFormatter.asText(rs);
-		} catch (final UnableToBuildSolRDFClientException exception) {
+			solrdf.add(new FileReader("/work/workspaces/solrdf/solrdf/solrdf/solrdf-integration-tests/src/test/resources/sample_data/faceting_test_dataset.nt"), "N-TRIPLES");
 			
+			solrdf.commit();
+			
+			CloseableResultSet rs = null;
+			try {
+				rs = solrdf.select("SELECT * WHERE {?s ?p ?o}");
+				System.out.println(ResultSetFormatter.asText(rs));
+				
+				Model m = solrdf.construct("DESCRIBE <http://example.org/book4>");
+				System.out.println(m);
+			} finally {
+				rs.close();
+			}
+		} catch (final UnableToBuildSolRDFClientException exception) {
+			exception.printStackTrace();
 		}
 	}
 }


### PR DESCRIPTION
I created a subclass of Jena Resulset in order to delegate the responsibility of resource release to ResultSet class (instead of QueryExecution). That simplifies the client code needed for executing a (SELECT) query. 